### PR TITLE
Update packages to preview 3

### DIFF
--- a/FunctionApp/FunctionApp.csproj
+++ b/FunctionApp/FunctionApp.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="4.0.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.2.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.0-preview1" OutputItemType="Analyzer" />
-    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.0.0-preview1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.0.0-preview3" OutputItemType="Analyzer"/>
+    <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.0.0-preview3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Update the worker SDK packages to preview 3 in the provided sample application.

This should alleviate some confusion around people pulling down this repository, adding dependencies (EF core 5, DI packages, etc) that were broken in preview 1 and have since been fixed.